### PR TITLE
Test internal links on production

### DIFF
--- a/Programming/AprilTags.md
+++ b/Programming/AprilTags.md
@@ -12,14 +12,14 @@ AprilTags are a vital part of the modern FRC control system. They allow a robot 
 
 ## PhotonVision
 
-Team 401 uses a piece of open-source software called [PhotonVision](https://photonvision.org) to run our vision pipeline. We recommend reading their [docs](https://docs.photonvision.org/en/latest) to learn how to set it up for your year. Also feel free to read [Common PhotonVision Problems](/Programming/PhotonVision-Problems.html).
+Team 401 uses a piece of open-source software called [PhotonVision](https://photonvision.org) to run our vision pipeline. We recommend reading their [docs](https://docs.photonvision.org/en/latest) to learn how to set it up for your year. Also feel free to read [Common PhotonVision Problems]({{ site.baseurl }}/Programming/PhotonVision-Problems.html).
 
 ## Overlayroot
 
-If you're using a Beelink or other mini-PC running Ubuntu Server, we recommend setting up `overlayroot` to ensure the operating system survives a sudden power loss. If the PC shuts of suddenly without overlayroot enabled, you risk breaking the OS installation, and you will have to reinstall. See [Using Overlayroot](/Programming/Using-Overlayroot.html) for more details.
+If you're using a Beelink or other mini-PC running Ubuntu Server, we recommend setting up `overlayroot` to ensure the operating system survives a sudden power loss. If the PC shuts of suddenly without overlayroot enabled, you risk breaking the OS installation, and you will have to reinstall. See [Using Overlayroot](/Docs/Programming/Using-Overlayroot.html) for more details.
 
 ## Kalman Filter
 
 As far as an FRC student is concerned, a Kalman filter is a giant pile of linear algebra that combines measurements from unreliable sources. For a robot pose estimator, one can specify expected standard deviations for the x-axis, the y-axis, and robot rotation or theta. For detailed, high school-level information on the mechanics of a Kalman filter, look [here](https://thekalmanfilter.com/kalman-filter-explained-simply/), [here](https://docs.wpilib.org/en/stable/docs/software/advanced-controls/state-space/state-space-observers.html), or at [the Matlab video series](https://youtu.be/mwn8xhgNpFY?si=U2H4U4Lw_r9oYQGj) on the subject. For information on using WPIlib's pose estimator object, look [here](https://docs.wpilib.org/en/stable/docs/software/advanced-controls/state-space/state-space-pose-estimators.html).
 
-For more information on what should inform AprilTag standard deviations, read [What Affects AprilTag Accuracy?](/Programming/AprilTag-Accuracy.html)
+For more information on what should inform AprilTag standard deviations, read [What Affects AprilTag Accuracy?](/Docs/Programming/AprilTag-Accuracy.html)

--- a/Programming/Getting-Started.md
+++ b/Programming/Getting-Started.md
@@ -20,24 +20,24 @@ First, you will need to [create a GitHub account](https://github.com) in order t
 ## Install Required Software
 
 Next, download the required software:
-- [Installing Git](/Programming/Installing-Git.html)
-- [Installing WPILib](/Programming/Installing-WPILib.html)
+- [Installing Git](/Docs/Programming/Installing-Git.html)
+- [Installing WPILib](/Docs/Programming/Installing-WPILib.html)
 
 After these programs are installed, your development environment is ready to use.
 
 ### Install Optional Software
 
-Consider installing some of the [Optional Software](/Programming/Optional-Software.html) as needed. Normally you do not need to do this unless you are the lead programmer or if you are working on specific hardware.
+Consider installing some of the [Optional Software](/Docs/Programming/Optional-Software.html) as needed. Normally you do not need to do this unless you are the lead programmer or if you are working on specific hardware.
 
 ## Learn the Language
 
-On 401, we use Java to program the robot. If you're coming from AP CSA, read the [Post-CSA Supplement](/Programming/Post-CSA.html). Otherwise, please learn Java.
+On 401, we use Java to program the robot. If you're coming from AP CSA, read the [Post-CSA Supplement](/Docs/Programming/Post-CSA.html). Otherwise, please learn Java.
 
 ## Understand the Process
 
 Becoming familiar with the following resources is required before contributing to the repository:
-- The [Software Development Workflow](/Programming/Software-Workflow.html) defines the process for making code changes on the team.
-- Learn about our [Coding Standards](/Programming/Coding-Standards.html) to ensure your code passes review.
+- The [Software Development Workflow](/Docs/Programming/Software-Workflow.html) defines the process for making code changes on the team.
+- Learn about our [Coding Standards](/Docs/Programming/Coding-Standards.html) to ensure your code passes review.
 
 
 


### PR DESCRIPTION
Right now, clicking on internal links on the deployed site leads to a 401 error, even though they work as expected when deploying locally. As a test, this change adds `{{ site.basename }}` before an internal link in _Using AprilTags_. This change still works locally, but we have to test it on the production site.