### PR TITLE
Add social card generator plugin, use group to avoid running it locally

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Docs
 site_url: https://team401.github.io
+site_description: "FIRST Robotics Competition documentation developed by \nFRC Team 401: Copperhead Robotics"
 
 repo_url: https://github.com/team401/Docs
 edit_uri: edit/main/docs/
@@ -59,6 +60,8 @@ plugins:
   - group:
       enabled: !ENV CI
       plugins:
-        - social
+        - social:
+            cards_layout_options:
+              background_color: "#d35401"
   - git-revision-date-localized:
       enable_creation_date: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,5 +56,9 @@ extra:
 
 plugins:
   - search
+  - group:
+      enabled: !ENV CI
+      plugins:
+        - social
   - git-revision-date-localized:
       enable_creation_date: true


### PR DESCRIPTION
This PR adds social card generation to the project. Not strictly necessary but nice to have. It uses the group plugin to avoid requiring users to install cairo and other dependencies [docs here for reference](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/#dependencies). 

Here's an example of what the cards will look like:
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/cf7ddbdb-7bcc-459a-a69d-3eecce27348f" />
